### PR TITLE
Add TypeScript aliases and stricter template types

### DIFF
--- a/docs/api/BaseViewModel.md
+++ b/docs/api/BaseViewModel.md
@@ -19,8 +19,8 @@ constructor(context: PageJS.Context | undefined = undefined)
 ## Properties
 
 | Property        | Type                          | Description                                            |
-| --------------- | ----------------------------- | ------------------------------------------------------ |
-| `template`      | `string \| null`              | The HTML template for the view.                        |
+| --------------- | ----------------------------- | ------------------------------------------------------ | ------------------------------- |
+| `template`      | `string                       | undefined`                                             | The HTML template for the view. |
 | `context`       | `PageJS.Context \| undefined` | The current routing context.                           |
 | `selector`      | `string \| null`              | The DOM selector where the view is rendered.           |
 | `isSubTemplate` | `boolean`                     | Indicates if this is a sub-template.                   |
@@ -49,7 +49,7 @@ Renders the view into the specified container.
 ### renderTemplate
 
 ```typescript
-public renderTemplate(template: string | null, context: PageJS.Context | undefined = undefined, selector = "app"): this
+public renderTemplate(template: string, context: PageJS.Context | undefined = undefined, selector = "app"): this
 ```
 
 Sets the template and renders it in the specified container.
@@ -97,7 +97,7 @@ Gets the current context of the view.
 ### setTemplate
 
 ```typescript
-public setTemplate(template: string | null): this
+public setTemplate(template: string): this
 ```
 
 Sets the template for the view.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -27,10 +27,10 @@ This document contains a comprehensive list of improvement tasks for the Knockou
 
 ## Code Quality and Development Experience
 
-5. [ ] Improve TypeScript configuration
-    - [ ] Add path aliases for cleaner imports
-    - [ ] Configure source maps for better debugging
-    - [ ] Implement stricter type checking for templates
+5. [x] Improve TypeScript configuration
+    - [x] Add path aliases for cleaner imports
+    - [x] Configure source maps for better debugging
+    - [x] Implement stricter type checking for templates
 
 6. [x] Set up comprehensive linting and formatting
     - [x] Add ESLint with appropriate rules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
     "name": "knockout-page-vite",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "knockout-page-vite",
-            "version": "0.0.0",
+            "version": "1.0.0",
             "dependencies": {
                 "knockout": "^3.5.1",
                 "page": "^1.11.6"
             },
             "devDependencies": {
                 "@types/knockout": "^3.4.77",
+                "@types/node": "^24.1.0",
                 "@types/page": "^1.11.9",
                 "@typescript-eslint/eslint-plugin": "^8.38.0",
                 "@typescript-eslint/parser": "^8.38.0",
@@ -957,6 +958,16 @@
             "integrity": "sha512-RpujDayUysbJlpygCxDnMSOp7DeUIROcoIW0Xf85YkqoZ/DE5R2R4TcFhbgLaGTM5bi4QLTVSG/DUUc0wL4KmQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+            "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.8.0"
+            }
         },
         "node_modules/@types/page": {
             "version": "1.11.9",
@@ -3168,6 +3179,13 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+            "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     },
     "devDependencies": {
         "@types/knockout": "^3.4.77",
+        "@types/node": "^24.1.0",
         "@types/page": "^1.11.9",
         "@typescript-eslint/eslint-plugin": "^8.38.0",
         "@typescript-eslint/parser": "^8.38.0",

--- a/src/components/AboutViewModel.ts
+++ b/src/components/AboutViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel } from '../core/BaseViewModel';
+import { BaseViewModel } from '@core/BaseViewModel';
 
 export class AboutViewModel extends BaseViewModel {
     constructor(context: PageJS.Context | undefined) {

--- a/src/components/AccessDeniedViewModel.ts
+++ b/src/components/AccessDeniedViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel } from '../core/BaseViewModel';
+import { BaseViewModel } from '@core/BaseViewModel';
 
 export class AccessDeniedViewModel extends BaseViewModel {
     constructor(context: PageJS.Context | undefined) {

--- a/src/components/AdminViewModel.ts
+++ b/src/components/AdminViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel } from '../core/BaseViewModel';
+import { BaseViewModel } from '@core/BaseViewModel';
 
 export class AdminViewModel extends BaseViewModel {
     constructor(context: PageJS.Context | undefined) {

--- a/src/components/AppViewModel.ts
+++ b/src/components/AppViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel } from '../core/BaseViewModel';
+import { BaseViewModel } from '@core/BaseViewModel';
 
 export class AppViewModel extends BaseViewModel {
     constructor(context: PageJS.Context | undefined) {

--- a/src/components/DashboardHomeViewModel.ts
+++ b/src/components/DashboardHomeViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel } from '../core/BaseViewModel';
+import { BaseViewModel } from '@core/BaseViewModel';
 
 export class DashboardHomeViewModel extends BaseViewModel {
     constructor(context: PageJS.Context | undefined) {

--- a/src/components/DashboardProfileViewModel.ts
+++ b/src/components/DashboardProfileViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel } from '../core/BaseViewModel';
+import { BaseViewModel } from '@core/BaseViewModel';
 
 export class DashboardProfileViewModel extends BaseViewModel {
     constructor(context: PageJS.Context | undefined) {

--- a/src/components/DashboardSettingsViewModel.ts
+++ b/src/components/DashboardSettingsViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel } from '../core/BaseViewModel';
+import { BaseViewModel } from '@core/BaseViewModel';
 
 export class DashboardSettingsViewModel extends BaseViewModel {
     constructor(context: PageJS.Context | undefined) {

--- a/src/components/DashboardViewModel.ts
+++ b/src/components/DashboardViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel, renderView } from '../core/BaseViewModel';
+import { BaseViewModel, renderView } from '@core/BaseViewModel';
 
 export class DashboardViewModel extends BaseViewModel {
     private contentContainer = 'dashboard-content';

--- a/src/components/LoginViewModel.ts
+++ b/src/components/LoginViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel } from '../core/BaseViewModel';
+import { BaseViewModel } from '@core/BaseViewModel';
 import page from 'page';
 
 export class LoginViewModel extends BaseViewModel {

--- a/src/components/NotFoundViewModel.ts
+++ b/src/components/NotFoundViewModel.ts
@@ -1,4 +1,4 @@
-import { BaseViewModel } from '../core/BaseViewModel';
+import { BaseViewModel } from '@core/BaseViewModel';
 
 export class NotFoundViewModel extends BaseViewModel {
     constructor(context: PageJS.Context | undefined) {

--- a/src/core/BaseViewModel.ts
+++ b/src/core/BaseViewModel.ts
@@ -1,7 +1,7 @@
 import { applyBindings, cleanNode, dataFor } from 'knockout';
 
 export class BaseViewModel {
-    protected template: string | null = null;
+    protected template?: string;
     protected context: PageJS.Context | undefined;
     protected selector: string | null = null;
     protected isSubTemplate = false;
@@ -51,7 +51,7 @@ export class BaseViewModel {
      * @returns The instance of BaseViewModel to allow method chaining.
      */
     public renderTemplate(
-        template: string | null,
+        template: string,
         context: PageJS.Context | undefined = undefined,
         selector = 'app'
     ): this {
@@ -103,7 +103,7 @@ export class BaseViewModel {
      * @param template - The template HTML.
      * @returns The instance of BaseViewModel to allow method chaining.
      */
-    public setTemplate(template: string | null): this {
+    public setTemplate(template: string): this {
         this.template = template;
         this.injectTemplateScript();
         return this;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
 import page from 'page';
-import { registerRoutes } from './routes/routes';
+import { registerRoutes } from '@routes/routes';
 
 registerRoutes(page);

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,19 +1,19 @@
-import { renderView } from '../core/BaseViewModel';
-import { AppViewModel } from '../components/AppViewModel';
-import { NotFoundViewModel } from '../components/NotFoundViewModel';
+import { renderView } from '@core/BaseViewModel';
+import { AppViewModel } from '@components/AppViewModel';
+import { NotFoundViewModel } from '@components/NotFoundViewModel';
 import {
     logPathMiddleware,
     authGuard,
     roleGuard,
-} from '../middlewares/middlewares';
-import { AboutViewModel } from '../components/AboutViewModel.ts';
-import { DashboardViewModel } from '../components/DashboardViewModel';
-import { DashboardHomeViewModel } from '../components/DashboardHomeViewModel';
-import { DashboardProfileViewModel } from '../components/DashboardProfileViewModel';
-import { DashboardSettingsViewModel } from '../components/DashboardSettingsViewModel';
-import { AdminViewModel } from '../components/AdminViewModel';
-import { LoginViewModel } from '../components/LoginViewModel';
-import { AccessDeniedViewModel } from '../components/AccessDeniedViewModel';
+} from '@middlewares/middlewares';
+import { AboutViewModel } from '@components/AboutViewModel.ts';
+import { DashboardViewModel } from '@components/DashboardViewModel';
+import { DashboardHomeViewModel } from '@components/DashboardHomeViewModel';
+import { DashboardProfileViewModel } from '@components/DashboardProfileViewModel';
+import { DashboardSettingsViewModel } from '@components/DashboardSettingsViewModel';
+import { AdminViewModel } from '@components/AdminViewModel';
+import { LoginViewModel } from '@components/LoginViewModel';
+import { AccessDeniedViewModel } from '@components/AccessDeniedViewModel';
 
 /**
  * Route configuration interface

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,15 @@
         "noUnusedParameters": true,
         "erasableSyntaxOnly": true,
         "noFallthroughCasesInSwitch": true,
-        "noUncheckedSideEffectImports": true
+        "noUncheckedSideEffectImports": true,
+        "sourceMap": true,
+        "baseUrl": "./src",
+        "paths": {
+            "@components/*": ["components/*"],
+            "@core/*": ["core/*"],
+            "@middlewares/*": ["middlewares/*"],
+            "@routes/*": ["routes/*"]
+        }
     },
-    "include": ["src"]
+    "include": ["src", "vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            '@components': path.resolve(__dirname, 'src/components'),
+            '@core': path.resolve(__dirname, 'src/core'),
+            '@middlewares': path.resolve(__dirname, 'src/middlewares'),
+            '@routes': path.resolve(__dirname, 'src/routes'),
+        },
+    },
+    build: {
+        sourcemap: true,
+    },
+});


### PR DESCRIPTION
## Summary
- add source maps and path aliases in tsconfig
- generate source maps in Vite and configure module aliases
- use path aliases across the codebase
- enforce non-null template strings
- update API docs and tasks list
- add @types/node for build