### PR TITLE
Add central store with persistence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -136,6 +136,7 @@ Middleware functions can be used to:
 - Use Knockout observables for reactive state
 - Consider service singletons for shared state
 - Use the route context to pass state between routes
+- Persist global data using the built-in observable store in `src/store`
 
 ### Error Handling
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -222,6 +222,25 @@ For shared state between components, the application can use several approaches:
     const user = JSON.parse(localStorage.getItem('user'));
     ```
 
+### Centralized Store
+
+A lightweight observable store is provided in `src/store`. It keeps global
+application state in a single Knockout observable and automatically persists
+changes to `localStorage` by default. Derived state can be defined using the
+store's `computed` helper:
+
+```typescript
+import { appStore, isAuthenticated } from '@store/AppStore';
+
+// Access or update state
+appStore.setState({ authToken: 'demo' });
+
+// Derived value
+if (isAuthenticated()) {
+    // user is logged in
+}
+```
+
 ## Data Flow
 
 The data flow in the application follows these patterns:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -4,10 +4,10 @@ This document contains a comprehensive list of improvement tasks for the Knockou
 
 ## Architecture and Structure
 
-1. [ ] Implement a proper state management solution
-    - [ ] Create a centralized store for application state
-    - [ ] Add support for computed properties and state derivation
-    - [ ] Implement proper state persistence (localStorage/sessionStorage)
+1. [x] Implement a proper state management solution
+    - [x] Create a centralized store for application state
+    - [x] Add support for computed properties and state derivation
+    - [x] Implement proper state persistence (localStorage/sessionStorage)
 
 2. [ ] Enhance component architecture
     - [ ] Create a component registry for better organization

--- a/src/components/LoginViewModel.ts
+++ b/src/components/LoginViewModel.ts
@@ -1,10 +1,10 @@
 import { BaseViewModel } from '@core/BaseViewModel';
 import page from 'page';
+import { setAuth } from '@store/AppStore';
 
 export class LoginViewModel extends BaseViewModel {
     public performLogin = (): void => {
-        localStorage.setItem('auth_token', 'demo');
-        localStorage.setItem('user_role', 'admin');
+        setAuth('demo', 'admin');
         page.redirect('/dashboard');
     };
 

--- a/src/middlewares/middlewares.ts
+++ b/src/middlewares/middlewares.ts
@@ -1,4 +1,5 @@
 import page from 'page';
+import { appStore } from '@store/AppStore';
 
 export function logPathMiddleware(
     context: { path: string },
@@ -12,8 +13,8 @@ export function logPathMiddleware(
 }
 
 export function authGuard(_context: PageJS.Context, next: () => void): void {
-    const token = localStorage.getItem('auth_token');
-    if (token) {
+    const { authToken } = appStore.getState();
+    if (authToken) {
         next();
     } else {
         console.warn('Authentication required. Redirecting to login page.');
@@ -23,7 +24,7 @@ export function authGuard(_context: PageJS.Context, next: () => void): void {
 
 export function roleGuard(requiredRole: string) {
     return (_context: PageJS.Context, next: () => void): void => {
-        const userRole = localStorage.getItem('user_role');
+        const { userRole } = appStore.getState();
         if (userRole === requiredRole) {
             next();
         } else {

--- a/src/store/AppStore.ts
+++ b/src/store/AppStore.ts
@@ -1,0 +1,19 @@
+import { createStore } from './Store';
+
+export interface AppState {
+    authToken: string | null;
+    userRole: string | null;
+}
+
+export const appStore = createStore<AppState>(
+    { authToken: null, userRole: null },
+    { storage: 'localStorage', storageKey: 'app_state' }
+);
+
+export const isAuthenticated = appStore.computed(
+    (state) => state.authToken !== null && state.authToken !== ''
+);
+
+export const setAuth = (token: string | null, role: string | null): void => {
+    appStore.setState({ authToken: token, userRole: role });
+};

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -1,0 +1,65 @@
+import * as ko from 'knockout';
+
+export type StorageType = 'localStorage' | 'sessionStorage';
+
+export interface StoreOptions {
+    storage?: StorageType;
+    storageKey?: string;
+}
+
+export class Store<T> {
+    private state: KnockoutObservable<T>;
+    private storage?: StorageType;
+    private storageKey: string;
+
+    constructor(initialState: T, options: StoreOptions = {}) {
+        this.storage = options.storage;
+        this.storageKey = options.storageKey || 'app_state';
+        const persisted = this.load();
+        this.state = ko.observable({ ...initialState, ...persisted });
+        this.state.subscribe(() => this.save());
+    }
+
+    public getState(): T {
+        return this.state();
+    }
+
+    public setState(partial: Partial<T>): void {
+        this.state({ ...this.state(), ...partial });
+    }
+
+    public computed<U>(fn: (state: T) => U): KnockoutComputed<U> {
+        return ko.pureComputed(() => fn(this.state()));
+    }
+
+    public subscribe(callback: (state: T) => void): KnockoutSubscription {
+        return this.state.subscribe(callback);
+    }
+
+    private save(): void {
+        if (!this.storage) return;
+        try {
+            const storage = window[this.storage];
+            storage.setItem(this.storageKey, JSON.stringify(this.state()));
+        } catch (err) {
+            console.error('Failed to persist state', err);
+        }
+    }
+
+    private load(): Partial<T> {
+        if (!this.storage) return {};
+        try {
+            const storage = window[this.storage];
+            const data = storage.getItem(this.storageKey);
+            return data ? (JSON.parse(data) as T) : {};
+        } catch (err) {
+            console.error('Failed to load persisted state', err);
+            return {};
+        }
+    }
+}
+
+export const createStore = <T>(
+    initialState: T,
+    options?: StoreOptions
+): Store<T> => new Store(initialState, options);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
             "@components/*": ["components/*"],
             "@core/*": ["core/*"],
             "@middlewares/*": ["middlewares/*"],
-            "@routes/*": ["routes/*"]
+            "@routes/*": ["routes/*"],
+            "@store/*": ["store/*"]
         }
     },
     "include": ["src", "vite.config.ts"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
             '@core': path.resolve(__dirname, 'src/core'),
             '@middlewares': path.resolve(__dirname, 'src/middlewares'),
             '@routes': path.resolve(__dirname, 'src/routes'),
+            '@store': path.resolve(__dirname, 'src/store'),
         },
     },
     build: {


### PR DESCRIPTION
## Summary
- implement simple observable store with persistence and computed helpers
- create `AppStore` for global auth data
- integrate store into login and auth middleware
- document new state management approach
- update task list and configuration aliases