### PR TITLE
feat: enhance form handling with reusable components

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -77,10 +77,10 @@ This document contains a comprehensive list of improvement tasks for the Knockou
     - [ ] Implement keyboard navigation
     - [ ] Add screen reader support
 
-14. [ ] Enhance form handling
-    - [ ] Create reusable form components
-    - [ ] Implement form validation
-    - [ ] Add support for complex form workflows
+14. [x] Enhance form handling
+    - [x] Create reusable form components
+    - [x] Implement form validation
+    - [x] Add support for complex form workflows
 
 ## Documentation and Maintenance
 

--- a/src/components/ContactFormViewModel.ts
+++ b/src/components/ContactFormViewModel.ts
@@ -1,0 +1,71 @@
+import { observable } from 'knockout';
+import { FormViewModel, type ValidationRule } from '@core/FormViewModel';
+
+const required = (message: string): ValidationRule => ({
+    validator: (v: unknown) => typeof v === 'string' && v.trim().length > 0,
+    message,
+});
+
+const emailRule: ValidationRule = {
+    validator: (v: unknown) =>
+        typeof v === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
+    message: 'Invalid email address',
+};
+
+export class ContactFormViewModel extends FormViewModel {
+    public name = this.registerField('name', '', [
+        required('Name is required'),
+    ]);
+    public email = this.registerField('email', '', [
+        required('Email is required'),
+        emailRule,
+    ]);
+    public message = this.registerField('message', '', [
+        required('Message is required'),
+    ]);
+    public isSubmitted = observable(false);
+
+    constructor(context: PageJS.Context | undefined) {
+        super(context);
+        this.setSteps([['name', 'email'], ['message']]);
+        this.setTemplate(`
+            <div class="contact-form">
+                <form data-bind="submit: onSubmit">
+                    <!-- Step 1 -->
+                    <div data-bind="visible: currentStep() === 0">
+                        <div>
+                            <label for="name">Name</label>
+                            <input id="name" data-bind="value: name" />
+                            <span data-bind="text: errors.name"></span>
+                        </div>
+                        <div>
+                            <label for="email">Email</label>
+                            <input id="email" data-bind="value: email" />
+                            <span data-bind="text: errors.email"></span>
+                        </div>
+                        <button type="button" data-bind="click: nextStep">Next</button>
+                    </div>
+                    <!-- Step 2 -->
+                    <div data-bind="visible: currentStep() === 1">
+                        <div>
+                            <label for="message">Message</label>
+                            <textarea id="message" data-bind="value: message"></textarea>
+                            <span data-bind="text: errors.message"></span>
+                        </div>
+                        <button type="button" data-bind="click: prevStep">Back</button>
+                        <button type="submit">Submit</button>
+                    </div>
+                </form>
+                <div data-bind="visible: isSubmitted">
+                    <p>Thank you for your message!</p>
+                </div>
+            </div>
+        `);
+    }
+
+    public onSubmit = (): void => {
+        this.submit(() => {
+            this.isSubmitted(true);
+        });
+    };
+}

--- a/src/components/SimpleFormViewModel.ts
+++ b/src/components/SimpleFormViewModel.ts
@@ -1,0 +1,49 @@
+import { FormViewModel, type ValidationRule } from '@core/FormViewModel';
+
+const required = (message: string): ValidationRule => ({
+    validator: (v: unknown) => typeof v === 'string' && v.trim().length > 0,
+    message,
+});
+
+const emailRule: ValidationRule = {
+    validator: (v: unknown) =>
+        typeof v === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
+    message: 'Invalid email address',
+};
+
+export class SimpleFormViewModel extends FormViewModel {
+    public name = this.registerField('name', '', [
+        required('Name is required'),
+    ]);
+    public email = this.registerField('email', '', [
+        required('Email is required'),
+        emailRule,
+    ]);
+
+    constructor(context: PageJS.Context | undefined) {
+        super(context);
+        this.setTemplate(`
+            <div class="simple-form">
+                <form data-bind="submit: onSubmit">
+                    <div>
+                        <label for="name">Name</label>
+                        <input id="name" data-bind="value: name" />
+                        <span data-bind="text: errors.name"></span>
+                    </div>
+                    <div>
+                        <label for="email">Email</label>
+                        <input id="email" data-bind="value: email" />
+                        <span data-bind="text: errors.email"></span>
+                    </div>
+                    <button type="submit">Submit</button>
+                </form>
+            </div>
+        `);
+    }
+
+    public onSubmit = (): void => {
+        this.submit(() => {
+            console.log(this.getValues());
+        });
+    };
+}

--- a/src/core/FormViewModel.ts
+++ b/src/core/FormViewModel.ts
@@ -1,0 +1,77 @@
+import { observable } from 'knockout';
+import { BaseViewModel } from './BaseViewModel';
+
+export interface ValidationRule {
+    validator: (value: unknown) => boolean;
+    message: string;
+}
+
+export type StepConfig = string[];
+
+export class FormViewModel extends BaseViewModel {
+    public fields: Record<string, KnockoutObservable<unknown>> = {};
+    public errors: Record<string, KnockoutObservable<string | null>> = {};
+    private rules: Record<string, ValidationRule[]> = {};
+    private steps: StepConfig[] = [];
+    public currentStep = observable(0);
+
+    protected registerField(
+        name: string,
+        initialValue: unknown = '',
+        rules: ValidationRule[] = []
+    ): KnockoutObservable<unknown> {
+        this.fields[name] = observable(initialValue);
+        this.errors[name] = observable<string | null>(null);
+        this.rules[name] = rules;
+        return this.fields[name];
+    }
+
+    public setSteps(steps: StepConfig[]): void {
+        this.steps = steps;
+    }
+
+    public validateField(name: string): boolean {
+        const rules = this.rules[name];
+        const field = this.fields[name];
+        if (!rules || !field) return true;
+        for (const rule of rules) {
+            if (!rule.validator(field())) {
+                this.errors[name]?.(rule.message);
+                return false;
+            }
+        }
+        this.errors[name]?.(null);
+        return true;
+    }
+
+    public validateStep(stepIndex = this.currentStep()): boolean {
+        const step = this.steps[stepIndex];
+        if (!step) return true;
+        return step.every((name) => this.validateField(name));
+    }
+
+    public validate(): boolean {
+        return Object.keys(this.fields).every((name) =>
+            this.validateField(name)
+        );
+    }
+
+    public nextStep(): void {
+        if (this.currentStep() >= this.steps.length - 1) return;
+        if (this.validateStep(this.currentStep())) {
+            this.currentStep(this.currentStep() + 1);
+        }
+    }
+
+    public prevStep(): void {
+        if (this.currentStep() > 0) {
+            this.currentStep(this.currentStep() - 1);
+        }
+    }
+
+    public submit(handler: () => void): void {
+        if (this.validate()) {
+            handler();
+        }
+    }
+}

--- a/src/core/FormViewModel.ts
+++ b/src/core/FormViewModel.ts
@@ -56,6 +56,14 @@ export class FormViewModel extends BaseViewModel {
         );
     }
 
+    public getValues(): Record<string, unknown> {
+        const values: Record<string, unknown> = {};
+        Object.keys(this.fields).forEach((name) => {
+            values[name] = this.fields[name]();
+        });
+        return values;
+    }
+
     public nextStep(): void {
         if (this.currentStep() >= this.steps.length - 1) return;
         if (this.validateStep(this.currentStep())) {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -6,7 +6,7 @@ import {
     authGuard,
     roleGuard,
 } from '@middlewares/middlewares';
-import { AboutViewModel } from '@components/AboutViewModel.ts';
+import { AboutViewModel } from '@components/AboutViewModel';
 import { DashboardViewModel } from '@components/DashboardViewModel';
 import { DashboardHomeViewModel } from '@components/DashboardHomeViewModel';
 import { DashboardProfileViewModel } from '@components/DashboardProfileViewModel';
@@ -15,6 +15,7 @@ import { AdminViewModel } from '@components/AdminViewModel';
 import { LoginViewModel } from '@components/LoginViewModel';
 import { AccessDeniedViewModel } from '@components/AccessDeniedViewModel';
 import { ContactFormViewModel } from '@components/ContactFormViewModel';
+import { SimpleFormViewModel } from '@components/SimpleFormViewModel';
 
 /**
  * Route configuration interface
@@ -87,6 +88,10 @@ export const routes: RouteConfig[] = [
     {
         path: '/contact',
         handler: (context) => renderView(ContactFormViewModel, context),
+    },
+    {
+        path: '/simple-form',
+        handler: (context) => renderView(SimpleFormViewModel, context),
     },
     {
         path: '/access-denied',

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -14,6 +14,7 @@ import { DashboardSettingsViewModel } from '@components/DashboardSettingsViewMod
 import { AdminViewModel } from '@components/AdminViewModel';
 import { LoginViewModel } from '@components/LoginViewModel';
 import { AccessDeniedViewModel } from '@components/AccessDeniedViewModel';
+import { ContactFormViewModel } from '@components/ContactFormViewModel';
 
 /**
  * Route configuration interface
@@ -82,6 +83,10 @@ export const routes: RouteConfig[] = [
     {
         path: '/login',
         handler: (context) => renderView(LoginViewModel, context),
+    },
+    {
+        path: '/contact',
+        handler: (context) => renderView(ContactFormViewModel, context),
     },
     {
         path: '/access-denied',

--- a/tests/FormViewModel.test.ts
+++ b/tests/FormViewModel.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { FormViewModel } from '../src/core/FormViewModel';
+
+class TestForm extends FormViewModel {
+    public name = this.registerField('name', '', [
+        {
+            validator: (v) => typeof v === 'string' && v.length > 0,
+            message: 'required',
+        },
+    ]);
+    public age = this.registerField('age', 0, [
+        {
+            validator: (v) => typeof v === 'number' && v > 0,
+            message: 'invalid age',
+        },
+    ]);
+    constructor() {
+        super(undefined);
+        this.setSteps([['name'], ['age']]);
+    }
+}
+
+describe('FormViewModel', () => {
+    it('validates fields', () => {
+        const form = new TestForm();
+        expect(form.validate()).toBe(false);
+        expect(form.errors.name()).toBe('required');
+        form.name('John');
+        form.age(10);
+        expect(form.validate()).toBe(true);
+    });
+
+    it('supports step navigation', () => {
+        const form = new TestForm();
+        form.nextStep();
+        expect(form.currentStep()).toBe(0);
+        form.name('Jane');
+        form.nextStep();
+        expect(form.currentStep()).toBe(1);
+        form.prevStep();
+        expect(form.currentStep()).toBe(0);
+    });
+});

--- a/tests/FormViewModel.test.ts
+++ b/tests/FormViewModel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { FormViewModel } from '../src/core/FormViewModel';
 
 class TestForm extends FormViewModel {
@@ -39,5 +39,31 @@ describe('FormViewModel', () => {
         expect(form.currentStep()).toBe(1);
         form.prevStep();
         expect(form.currentStep()).toBe(0);
+    });
+
+    it('submits and returns values without steps', () => {
+        class SimpleForm extends FormViewModel {
+            public name = this.registerField('name', '', [
+                {
+                    validator: (v) => typeof v === 'string' && v.length > 0,
+                    message: 'required',
+                },
+            ]);
+            public email = this.registerField('email', '', [
+                {
+                    validator: (v) => typeof v === 'string' && v.includes('@'),
+                    message: 'invalid',
+                },
+            ]);
+        }
+        const form = new SimpleForm();
+        const handler = vi.fn();
+        form.name('Alice');
+        form.email('alice@example.com');
+        form.submit(() => handler(form.getValues()));
+        expect(handler).toHaveBeenCalledWith({
+            name: 'Alice',
+            email: 'alice@example.com',
+        });
     });
 });


### PR DESCRIPTION
## Summary
- add `FormViewModel` for reusable fields, validation and multi-step workflows
- provide `ContactFormViewModel` example and route
- document completed form tasks and add unit tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
